### PR TITLE
Adding NodeBehaviors + fixes to Coroutine Deadlocks + TryStep

### DIFF
--- a/jakta-api/src/commonMain/kotlin/it/unibo/jakta/agent/AgentLifecycle.kt
+++ b/jakta-api/src/commonMain/kotlin/it/unibo/jakta/agent/AgentLifecycle.kt
@@ -1,5 +1,7 @@
 package it.unibo.jakta.agent
 
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 
 /**
@@ -18,12 +20,10 @@ interface AgentLifecycle<Belief : Any, Goal : Any, Skills : Any> {
      * Potentially launches plans as a response to the event.
      * @param scope must be a SupervisorScope
      */
-    // TODO can we remove the scope?
-    // TODO we can definitely improve the documentation here
-    suspend fun step(scope: CoroutineScope)
+    suspend fun step()
 
     /**
      * Runs a reasoning cycle step if an event is available, otherwise does nothing.
      */
-    fun tryStep(scope: CoroutineScope)
+    fun tryStep(dispatcher: CoroutineDispatcher)
 }

--- a/jakta-api/src/commonMain/kotlin/it/unibo/jakta/intention/IntentionDispatcher.kt
+++ b/jakta-api/src/commonMain/kotlin/it/unibo/jakta/intention/IntentionDispatcher.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Delay
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.job
 
 /**
  * A [ContinuationInterceptor] that wraps another interceptor and implements [Delay] by delegating
@@ -47,6 +48,9 @@ class IntentionDispatcher(wrappedInterceptor: ContinuationInterceptor) :
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         log.d { "Intercepting continuation with context: $context" }
         val currentIntention: Intention = context[Intention] as Intention
-        currentIntention.enqueue { block.run() }
+        //TODO is this enough
+        if(currentIntention.job.isActive) {
+            currentIntention.enqueue { block.run() }
+        }
     }
 }

--- a/jakta-api/src/commonMain/kotlin/it/unibo/jakta/intention/IntentionDispatcher.kt
+++ b/jakta-api/src/commonMain/kotlin/it/unibo/jakta/intention/IntentionDispatcher.kt
@@ -48,7 +48,6 @@ class IntentionDispatcher(wrappedInterceptor: ContinuationInterceptor) :
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         log.d { "Intercepting continuation with context: $context" }
         val currentIntention: Intention = context[Intention] as Intention
-        //TODO is this enough
         if(currentIntention.job.isActive) {
             currentIntention.enqueue { block.run() }
         }

--- a/jakta-api/src/commonMain/kotlin/it/unibo/jakta/node/Node.kt
+++ b/jakta-api/src/commonMain/kotlin/it/unibo/jakta/node/Node.kt
@@ -23,6 +23,11 @@ interface Node<Body : Any, Skills : Any> {
     val agents: Map<AgentID, Body>
 
     /**
+     * A collection of behaviors that should run within the node in parallel with agents.
+     */
+    val behaviors: Collection<NodeBehavior<Body, Skills>>
+
+    /**
      * An event stream that emits system events related to the node.
      */
     val systemEvents: EventStream<SystemEvent>
@@ -46,6 +51,11 @@ interface Node<Body : Any, Skills : Any> {
      * @param id The unique identifier of the agent to be removed.
      */
     fun removeAgent(id: AgentID)
+
+    /**
+     * Adds a new behavior to the node.
+     */
+    fun addBehavior(behavior: NodeBehavior<Body,Skills>)
 
     /**
      * Terminates the node, effectively shutting down all agents and stopping any ongoing processes within the node.

--- a/jakta-api/src/commonMain/kotlin/it/unibo/jakta/node/NodeBehavior.kt
+++ b/jakta-api/src/commonMain/kotlin/it/unibo/jakta/node/NodeBehavior.kt
@@ -1,0 +1,5 @@
+package it.unibo.jakta.node
+
+interface NodeBehavior<Body: Any, Skills: Any> {
+    suspend fun start(node: Node<Body, Skills>)
+}

--- a/jakta-api/src/jvmMain/kotlin/it/unibo/jakta/reflection/Main.kt
+++ b/jakta-api/src/jvmMain/kotlin/it/unibo/jakta/reflection/Main.kt
@@ -1,0 +1,69 @@
+package it.unibo.jakta
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlin.coroutines.*
+
+sealed interface Event {
+    class Goal(val block: suspend () -> Unit) : Event
+    class Continuation(val runnable: Runnable) : Event
+}
+
+fun main() = runBlocking {
+    // Unlimited channel for events
+    val eventChannel = Channel<Event>(Channel.UNLIMITED)
+
+    // Supervisor for all event coroutines
+    val supervisor = SupervisorJob()
+    val scope = CoroutineScope(coroutineContext + supervisor)
+
+    // Custom dispatcher that re-enqueues continuations back into the channel
+    val dispatcher = object : CoroutineDispatcher() {
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            val job = context[Job]
+            if (job?.isActive == true) {
+                eventChannel.trySend(Event.Continuation(block))
+            }
+        }
+    }
+
+    // Processor coroutine: stops automatically when the scope is cancelled
+    val processor = scope.launch {
+        while (isActive) {
+            when (val event = eventChannel.receive()) {
+
+                is Event.Goal -> {
+                    // Start a new coroutine
+                    //THIS IS THE KEY -> The plans should not be children of the agent, but siblings of the agent
+                    scope.launch(dispatcher) {
+                            event.block()
+                    }
+                }
+
+                is Event.Continuation -> {
+                    // Actually execute continuation
+                    event.runnable.run()
+                }
+            }
+        }
+    }
+
+    // Event 1: long-running
+    eventChannel.send(Event.Goal {
+        println("Event 1 start")
+        delay(1000)
+        println("Event 1 end")
+    })
+
+    eventChannel.send(Event.Goal {
+        println("Event 2 start")
+        delay(300)
+        println("Cancelling scope")
+        scope.cancel()
+        println("Event 2 end")
+    })
+
+    // Give enough time for events to process
+    processor.join()
+    println("Main done")
+}

--- a/jakta-base-dsl/src/commonMain/kotlin/it/unibo/jakta/EntryPoint.kt
+++ b/jakta-base-dsl/src/commonMain/kotlin/it/unibo/jakta/EntryPoint.kt
@@ -1,5 +1,9 @@
 package it.unibo.jakta
 
+import it.unibo.jakta.agent.Agent
+import it.unibo.jakta.agent.AgentBuilder
+import it.unibo.jakta.agent.AgentBuilderImpl
+import it.unibo.jakta.agent.AgentSpecification
 import it.unibo.jakta.node.Node
 import it.unibo.jakta.node.LocalNodeBuilder
 import it.unibo.jakta.plan.Plan
@@ -23,19 +27,20 @@ fun <Belief : Any, Goal : Any, Skills : Any, Body : Any> node(
     return nodeBuilder.build()
 } //TODO now this is bound to local
 
-// TODO Fix this (now it needs to have a reference to the environment to instantiate skills)
-// /**
-// * Entry point for creating an agent using the Jakta DSL.
-// * @return an instantiated Agent.
-// */
-// @JaktaDSL
-// fun <Belief : Any, Goal : Any, Skills : Any> agent(
-//    block: AgentBuilder<Belief, Goal, Skills>.() -> Unit,
-// ): Agent<Belief, Goal> {
-//    val ab = AgentBuilderImpl<Belief, Goal, Skills>()
-//    ab.apply(block)
-//    return ab.build()
-// }
+
+ /**
+ * Entry point for creating an agent using the Jakta DSL.
+ * @return an instantiated Agent.
+ */
+ @JaktaDSL
+ fun <Belief : Any, Goal : Any, Skills : Any, Body: Any> agent(
+     node: Node<Body, Skills>,
+     block: AgentBuilder<Belief, Goal, Skills, Body>.() -> Unit,
+ ): AgentSpecification<Belief, Goal, Skills, Body> {
+    val ab = AgentBuilderImpl<Belief, Goal, Skills, Body>()
+    ab.apply(block)
+    return ab.build(node)
+ }
 
 // TODO entrypoint for plans???
 // this is tricky due to the way the DSL is constructed

--- a/jakta-base-dsl/src/commonMain/kotlin/it/unibo/jakta/node/NodeBuilder.kt
+++ b/jakta-base-dsl/src/commonMain/kotlin/it/unibo/jakta/node/NodeBuilder.kt
@@ -29,6 +29,8 @@ interface NodeBuilder<Belief : Any, Goal : Any, Skills : Any, Body : Any, N: Nod
 //     */
 //    fun withAgents(vararg agents: Agent<Belief, Goal>)
 
+    fun withBehavior(block: () -> NodeBehavior<Body, Skills>)
+
     /**
      * Builds and returns the Node instance.
      */
@@ -40,13 +42,19 @@ interface NodeBuilder<Belief : Any, Goal : Any, Skills : Any, Body : Any, N: Nod
  */
 open class LocalNodeBuilder<Belief : Any, Goal : Any, Skills : Any, Body : Any> :
     NodeBuilder<Belief, Goal, Skills, Body, LocalNode<Body, Skills>> {
-    protected val agents = mutableListOf<AgentBuilder<Belief, Goal, Skills, Body>>()
+
     private val node = LocalNode<Body, Skills>()
+
+    protected val agents = mutableListOf<AgentBuilder<Belief, Goal, Skills, Body>>()
 
     override fun agent(block: AgentBuilder<Belief, Goal, Skills, Body>.() -> Unit) = buildAgent(null, block)
 
     override fun agent(name: String, block: AgentBuilder<Belief, Goal, Skills, Body>.() -> Unit) =
         buildAgent(name, block)
+
+    override fun withBehavior(block: () -> NodeBehavior<Body, Skills>) {
+            node.addBehavior(block())
+    }
 
     private fun buildAgent(name: String?, block: AgentBuilder<Belief, Goal, Skills, Body>.() -> Unit) {
         val agentBuilder = AgentBuilderImpl<Belief, Goal, Skills, Body>(name)

--- a/jakta-base-dsl/src/commonTest/kotlin/ManualStepNodeRunner.kt
+++ b/jakta-base-dsl/src/commonTest/kotlin/ManualStepNodeRunner.kt
@@ -1,0 +1,98 @@
+package it.unibo.jakta.node
+
+import it.unibo.jakta.agent.AgentLifecycle
+import it.unibo.jakta.agent.BaseAgentLifecycle
+import it.unibo.jakta.agent.ExecutableAgent
+import it.unibo.jakta.agent.AgentID
+import it.unibo.jakta.event.SystemEvent
+import kotlinx.coroutines.CoroutineDispatcher
+
+/**
+ * A NodeRunner where agent stepping is performed manually, one step at a time.
+ * Includes a method to step until no more events are available.
+ */
+class ManualStepNodeRunner<Body: Any, Skills: Any, N : Node<Body, Skills>> : NodeRunner<N> {
+
+    private val agents: MutableMap<AgentLifecycle<*, *, *>, Unit> = mutableMapOf()
+    private val _nodes: MutableSet<N> = mutableSetOf()
+    override val nodes: Set<N> get() = _nodes.toSet()
+
+    /**
+     * Adds a node to the runner. Processes immediate system events once.
+     */
+    override suspend fun run(node: N) {
+        _nodes += node
+        processSystemEvents(node)
+    }
+
+    /**
+     * Steps all agents once on the provided dispatcher.
+     */
+    fun stepAll(dispatcher: CoroutineDispatcher) {
+        agents.keys.forEach { it.tryStep(dispatcher) }
+    }
+
+    /**
+     * Steps a single agent by ID.
+     */
+    fun stepAgent(id: AgentID, dispatcher: CoroutineDispatcher) {
+        agents.keys.find { it.executableAgent.id == id }?.tryStep(dispatcher)
+    }
+
+    /**
+     * Steps all agents repeatedly until no events remain in the node or agents' inboxes.
+     */
+    fun stepUntilIdle(dispatcher: CoroutineDispatcher) {
+        var hasEvents: Boolean
+        do {
+            hasEvents = false
+            // Step all agents once
+            agents.keys.forEach {
+                it.tryStep(dispatcher)
+                if (it.executableAgent.events.tryNext() != null) hasEvents = true
+            }
+            // Check system events for each node
+            _nodes.forEach { node ->
+                while (true) {
+                    val event = node.systemEvents.tryNext() ?: break
+                    hasEvents = true
+                    when (event) {
+                        is SystemEvent.AgentAddition<*, *, *> -> addAgent(event.executableAgent)
+                        is SystemEvent.AgentRemoval -> removeAgent(event.id)
+                        is SystemEvent.ShutDownNode -> _nodes -= node
+                    }
+                }
+            }
+        } while (hasEvents)
+    }
+
+    /**
+     * Adds an agent manually.
+     */
+    fun addAgent(agent: ExecutableAgent<*, *, *>) {
+        val lifecycle = BaseAgentLifecycle(agent)
+        agents[lifecycle] = Unit
+    }
+
+    /**
+     * Removes an agent manually.
+     */
+    fun removeAgent(id: AgentID) {
+        val entry = agents.keys.find { it.executableAgent.id == id } ?: return
+        agents.remove(entry)
+    }
+
+    /**
+     * Processes immediate system events once.
+     */
+    private fun processSystemEvents(node: N) {
+        while (true) {
+            val event = node.systemEvents.tryNext() ?: break
+            when (event) {
+                is SystemEvent.AgentAddition<*, *, *> -> addAgent(event.executableAgent)
+                is SystemEvent.AgentRemoval -> removeAgent(event.id)
+                is SystemEvent.ShutDownNode -> _nodes -= node
+            }
+        }
+    }
+}

--- a/jakta-base-dsl/src/commonTest/kotlin/Utils.kt
+++ b/jakta-base-dsl/src/commonTest/kotlin/Utils.kt
@@ -8,10 +8,11 @@ fun <T> String.ifGoalMatch(goal: String, returnValue: T): T? = if (this == goal)
 
 fun String.ifGoalMatch(goal: String): Unit? = if (this == goal) Unit else null
 
-fun executeInTestScope(node: TestScope.() -> Node<*, *>) {
+//TODO Io questa la rimuoverei e proverei a creare un CoroutineTestRunner
+fun <Body : Any, Skills : Any> executeInTestScope(node: TestScope.() -> Node<Body, Skills>) {
     runTest {
         val job = launch {
-            CoroutineNodeRunner<Node<*, *>>().run(node())
+            CoroutineNodeRunner<Body, Skills, Node<Body, Skills>>().run(node())
         }
         job.join()
     }

--- a/jakta-base-dsl/src/commonTest/kotlin/examples/TestConcurrentDelay.kt
+++ b/jakta-base-dsl/src/commonTest/kotlin/examples/TestConcurrentDelay.kt
@@ -29,7 +29,7 @@ class TestConcurrentDelay {
                         agent.print("Hello...")
                         delay(10000)
                         agent.print("...World!")
-                        skills.terminateNode()
+                        //skills.terminateNode()
                     }
                     adding.goal {
                         ifGoalMatch("anotherGoal")
@@ -38,7 +38,7 @@ class TestConcurrentDelay {
                         agent.print("Running while waiting...")
                         delay(5000)
                         agent.print("I'm still faster!")
-                        //skills.terminateNode()
+                        skills.terminateNode()
                         //TODO killing the agent while a plan is suspended
                         // does not cancel the agent and the app remains dangling
                         // this is a bug
@@ -49,7 +49,7 @@ class TestConcurrentDelay {
 
     @BeforeTest
     fun setup() {
-        Logger.setMinSeverity(Severity.Error)
+        Logger.setMinSeverity(Severity.Debug)
     }
 
     @Test

--- a/jakta-base-dsl/src/commonTest/kotlin/examples/TestConcurrentDelay.kt
+++ b/jakta-base-dsl/src/commonTest/kotlin/examples/TestConcurrentDelay.kt
@@ -38,6 +38,10 @@ class TestConcurrentDelay {
                         agent.print("Running while waiting...")
                         delay(5000)
                         agent.print("I'm still faster!")
+                        //skills.terminateNode()
+                        //TODO killing the agent while a plan is suspended
+                        // does not cancel the agent and the app remains dangling
+                        // this is a bug
                     }
                 }
             }

--- a/jakta-base-dsl/src/commonTest/kotlin/examples/TestConcurrentDelay.kt
+++ b/jakta-base-dsl/src/commonTest/kotlin/examples/TestConcurrentDelay.kt
@@ -29,7 +29,7 @@ class TestConcurrentDelay {
                         agent.print("Hello...")
                         delay(10000)
                         agent.print("...World!")
-                        //skills.terminateNode()
+                        skills.terminateNode()
                     }
                     adding.goal {
                         ifGoalMatch("anotherGoal")
@@ -39,9 +39,6 @@ class TestConcurrentDelay {
                         delay(5000)
                         agent.print("I'm still faster!")
                         skills.terminateNode()
-                        //TODO killing the agent while a plan is suspended
-                        // does not cancel the agent and the app remains dangling
-                        // this is a bug
                     }
                 }
             }

--- a/jakta-base-dsl/src/commonTest/kotlin/examples/TestHelloDelay.kt
+++ b/jakta-base-dsl/src/commonTest/kotlin/examples/TestHelloDelay.kt
@@ -1,5 +1,6 @@
 package examples
 
+import NodeTerminationSkill
 import NodeTerminationSkillImpl
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
@@ -17,7 +18,7 @@ class TestHelloDelay {
         Logger.setMinSeverity(Severity.Debug)
         val timeToWait = 10000L
 
-        executeInTestScope {
+        executeInTestScope<Any, NodeTerminationSkill> {
             node {
                 agent {
                     body = object {}

--- a/jakta-base-dsl/src/commonTest/kotlin/examples/TestPlanFailure.kt
+++ b/jakta-base-dsl/src/commonTest/kotlin/examples/TestPlanFailure.kt
@@ -1,5 +1,6 @@
 package examples
 
+import NodeTerminationSkill
 import NodeTerminationSkillImpl
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
@@ -15,7 +16,7 @@ class TestPlanFailure {
     @Test
     fun testPlanFailureHandling() {
         Logger.setMinSeverity(Severity.Warn)
-        executeInTestScope {
+        executeInTestScope<Any, NodeTerminationSkill> {
             node {
                 agent {
                     body = object {}

--- a/jakta-base-dsl/src/commonTest/kotlin/examples/TestSpatialRobot.kt
+++ b/jakta-base-dsl/src/commonTest/kotlin/examples/TestSpatialRobot.kt
@@ -15,9 +15,14 @@ import it.unibo.jakta.event.AgentEvent
 import it.unibo.jakta.event.BeliefAddEvent
 import it.unibo.jakta.node
 import it.unibo.jakta.node.Node
+import it.unibo.jakta.node.NodeBehavior
 import it.unibo.jakta.plan.triggers
 import kotlin.test.Test
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class BodyWithPosition {
     var position2D: DoubleArray = doubleArrayOf(0.0, 0.0)
@@ -66,46 +71,43 @@ class GridMovement(val node: Node<BodyWithPosition, *>) : Movement<DoubleArray> 
 }
 
 // Skill with active behavior that "runs" in the environment
-interface TemperatureSensing {
-
-    suspend fun startSensing()
+interface TemperatureSensing<Body: Any, Skills: Any> : NodeBehavior<Body, Skills> {
 
     object Events {
         class Temperature internal constructor(val value: Float) : AgentEvent.External.Perception
 
         object Factory {
-            fun TemperatureSensing.temperature(value: Float): Temperature = Temperature(value)
+            fun TemperatureSensing<*, *>.temperature(value: Float): Temperature = Temperature(value)
         }
     }
 }
 
-// This skill is a singleton, shared by all agents using it
-class FixedIntervalTemperatureSensing(val node: Node<BodyWithPosition, *>) : TemperatureSensing {
-
-    //TODO WHO Invokes this? This is a behavior that should be handled by the node, and not by an agent
-    override suspend fun startSensing() {
+class FixedIntervalTemperatureSensing<Body: Any, Skills: Any> : TemperatureSensing<Body, Skills> {
+    override suspend fun start(node: Node<Body, Skills>) {
         while (true) {
-            delay(100)
+            delay(1000)
             val temp = (15..30).random() + (0..99).random() / 100f
             node.sendEvent(temperature(temp)) // TODO: all agents in the node will perceive the temperature
         }
     }
+
 }
 
 class CustomSkillSet(val node: Node<BodyWithPosition, *>) :
     Recharging by FixedTimeRecharging(node),
     Movement<DoubleArray> by GridMovement(node),
-    TemperatureSensing by FixedIntervalTemperatureSensing(node),
     NodeTerminationSkill by NodeTerminationSkillImpl(node)
 
 class TestSpatialRobot {
 
     val mas = node {
+
+        withBehavior { FixedIntervalTemperatureSensing() }
+
         agent("Vacuum") {
             body = BodyWithPosition()
             withSkills {
                 CustomSkillSet(it)
-                //TODO the factory is ok, but then the agent when running should start its skills
             }
 
             perceptionHandler = {
@@ -123,6 +125,9 @@ class TestSpatialRobot {
                 }
             }
 
+            believes {
+                +"temp(0)"
+            }
 
             hasInitialGoals {
                 !"goal"
@@ -141,11 +146,23 @@ class TestSpatialRobot {
                     }
                 }
 
+                adding.belief {
+                    """temp\(([\d.]+)\)""".toRegex()
+                        .find(this)
+                        ?.groupValues?.getOrNull(1)
+                        ?.toDoubleOrNull()
+                        ?.takeIf { it > 25 }
+                } triggers {
+                    agent.print("Temperature > 25: ${this.context}, terminating the node!")
+                    skills.terminateNode() //TODO broken termination
+                }
+
                 adding.belief { this } triggers {
                     agent.print("Now I believe ${this.context}")
                 }
             }
         }
+
     }
 
     @Test

--- a/jakta-base-dsl/src/commonTest/kotlin/examples/TestTryStep.kt
+++ b/jakta-base-dsl/src/commonTest/kotlin/examples/TestTryStep.kt
@@ -1,0 +1,91 @@
+package examples
+
+import NodeTerminationSkillImpl
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Severity
+import executeInTestScope
+import it.unibo.jakta.node
+import it.unibo.jakta.node.ManualStepNodeRunner
+import it.unibo.jakta.node.Node
+import it.unibo.jakta.plan.triggers
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+class TestTryStep {
+
+    var firstStep = false;
+    var secondStep = false;
+    var done = false;
+
+    val helloWorld: Node<Any, NodeTerminationSkillImpl> = node {
+        agent("Hello world agent") {
+            body = object {}
+            withSkills { NodeTerminationSkillImpl(it) }
+            believes {
+                +"testBelief"
+            }
+            hasPlans {
+                adding.belief {
+                    this.takeIf { it == "testBelief" }
+                } triggers {
+                    agent.print("Belief added: $context")
+                    agent.print("First step");
+                    firstStep = true;
+                    delay(1000);
+                    agent.print("Second step");
+                    secondStep = true;
+                    delay(1000)
+                    agent.print("Third step, done!");
+                    done = true;
+                    skills.terminateNode()
+                }
+            }
+        }
+    }
+
+    @BeforeTest
+    fun setup() {
+        Logger.setMinSeverity(Severity.Debug)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun testBeliefAddition() {
+        runTest {
+            val runner = ManualStepNodeRunner<Any, NodeTerminationSkillImpl, Node<Any, NodeTerminationSkillImpl>>()
+            runner.run(helloWorld)
+
+            val dispatcher1 = StandardTestDispatcher(testScheduler)
+
+            runner.stepAll(dispatcher1)
+            assertFalse(firstStep, "First step should not have been executed yet")
+
+            advanceUntilIdle()
+
+            val dispatcher2 = StandardTestDispatcher(testScheduler)
+
+            runner.stepAll(dispatcher2)
+            assertTrue(firstStep, "First step should have been executed")
+
+            advanceUntilIdle()
+
+            val dispatcher3 = StandardTestDispatcher(testScheduler)
+            runner.stepAll(dispatcher3)
+            assertTrue(secondStep, "Second step should have been executed")
+
+            advanceUntilIdle()
+
+            runner.stepAll(dispatcher3)
+            assertTrue(done, "Done should have been executed")
+        }
+    }
+
+}

--- a/jakta-base-impl/src/commonMain/kotlin/it/unibo/jakta/agent/BaseAgentLifecycle.kt
+++ b/jakta-base-impl/src/commonMain/kotlin/it/unibo/jakta/agent/BaseAgentLifecycle.kt
@@ -127,9 +127,8 @@ class BaseAgentLifecycle<Belief : Any, Goal : Any, Skills : Any>(
         plan: Plan<Belief, Goal, Skills, TriggerEntity, *, *>,
         completion: CompletableDeferred<Any?>? = null, // TODO Check if this Any? can be improved
     ) {
-        log.d { "Launching plan $plan for event $event" }
         val intention = executableAgent.state.mutableIntentionPool.nextIntention(event, this.coroutineContext.job)
-
+        log.d { "Launching plan $plan for event $event on intention $intention" }
         val interceptor =
             this.coroutineContext[ContinuationInterceptor] ?: error { "No ContinuationInterceptor in context" }
 
@@ -137,14 +136,15 @@ class BaseAgentLifecycle<Belief : Any, Goal : Any, Skills : Any>(
             // TODO maybe I should not suppress?? But I want to catch ALL exceptions..
             @Suppress("TooGenericExceptionCaught")
             try {
-                log.d { "Running plan $plan" }
+                log.d { "Running plan $plan for event $event" }
                 val result = plan.run(executableAgent.state, entity)
                 completion?.complete(result)
             } catch (e: Exception) {
                 handleFailure(event, e)
             }
+        }.invokeOnCompletion {
+            log.d {"Plan Completed: $plan for event $event" }
         }
-        log.d { "Launched plan $plan" }
     }
 
     private fun <TriggerEntity : Any> selectPlan(

--- a/jakta-base-impl/src/commonMain/kotlin/it/unibo/jakta/agent/BaseAgentLifecycle.kt
+++ b/jakta-base-impl/src/commonMain/kotlin/it/unibo/jakta/agent/BaseAgentLifecycle.kt
@@ -11,6 +11,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlin.collections.filter
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
 
 /**
  * A base implementation of the [it.unibo.jakta.agent.AgentLifecycle] interface
@@ -25,15 +29,21 @@ class BaseAgentLifecycle<Belief : Any, Goal : Any, Skills : Any>(
             executableAgent.id.displayName,
         )
 
-    override suspend fun step(scope: CoroutineScope) {
+    //TODO consider making this public or add a method to cancel it e.g. stop()
+    // so far it does not seem to be necessary
+    private val agentJob = SupervisorJob()
+
+    override suspend fun step() {
         log.i { "waiting for event..." }
         val event = executableAgent.events.next()
         log.i { "received event: $event" }
+        val scope = CoroutineScope(currentCoroutineContext() + agentJob)
         handleEvent(event, scope)
     }
 
-    override fun tryStep(scope: CoroutineScope) {
+    override fun tryStep(dispatcher: CoroutineDispatcher) {
         executableAgent.events.tryNext()?.let {
+            val scope = CoroutineScope(dispatcher + agentJob)
             handleEvent(it, scope)
         }
     }

--- a/jakta-base-impl/src/commonMain/kotlin/it/unibo/jakta/node/CoroutineNodeRunner.kt
+++ b/jakta-base-impl/src/commonMain/kotlin/it/unibo/jakta/node/CoroutineNodeRunner.kt
@@ -9,8 +9,11 @@ import it.unibo.jakta.event.SystemEvent
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 
@@ -52,10 +55,8 @@ class CoroutineNodeRunner<Body: Any, Skills: Any, N : Node<Body, Skills>> : Node
     private fun CoroutineScope.addAgent(node: N, agent: ExecutableAgent<*, *, *>) {
         val newAgent = BaseAgentLifecycle(agent)
         val newJob = launch {
-            supervisorScope {
-                while (isActive) {
-                    newAgent.step(this)
-                }
+            while (isActive) {
+                newAgent.step()
             }
         }
         agents += newAgent to newJob

--- a/jakta-base-impl/src/commonMain/kotlin/it/unibo/jakta/node/CoroutineNodeRunner.kt
+++ b/jakta-base-impl/src/commonMain/kotlin/it/unibo/jakta/node/CoroutineNodeRunner.kt
@@ -9,14 +9,15 @@ import it.unibo.jakta.event.SystemEvent
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 
 /**
  * A [it.unibo.jakta.node.NodeRunner] implementation that uses Kotlin coroutines to manage the execution of agents within a node.
  */
-class CoroutineNodeRunner<N : Node<*, *>> : NodeRunner<N> {
+class CoroutineNodeRunner<Body: Any, Skills: Any, N : Node<Body, Skills>> : NodeRunner<N> {
 
     private val agents: MutableMap<AgentLifecycle<*, *, *>, Job> = mutableMapOf()
 
@@ -31,17 +32,19 @@ class CoroutineNodeRunner<N : Node<*, *>> : NodeRunner<N> {
     )
 
     override suspend fun run(node: N) {
-        _nodes += node
         supervisorScope {
+            val appScope = this
+            _nodes += node
             launch {
-                while (true) {
+                while (isActive) {
                     when (val event = node.systemEvents.next()) {
-                        is SystemEvent.AgentAddition<*, *, *> -> addAgent(node, event.executableAgent)
+                        is SystemEvent.AgentAddition<*, *, *> -> appScope.addAgent(node, event.executableAgent)
                         is SystemEvent.AgentRemoval -> removeAgent(event.id)
-                        is SystemEvent.ShutDownNode -> stopNode(node)
+                        is SystemEvent.ShutDownNode -> appScope.stopNode(node)
                     }
                 }
             }
+            node.behaviors.forEach { launch {it.start(node)} }
         }
         logger.i("Node $node START")
     }
@@ -50,7 +53,7 @@ class CoroutineNodeRunner<N : Node<*, *>> : NodeRunner<N> {
         val newAgent = BaseAgentLifecycle(agent)
         val newJob = launch {
             supervisorScope {
-                while (true) {
+                while (isActive) {
                     newAgent.step(this)
                 }
             }
@@ -76,7 +79,7 @@ class CoroutineNodeRunner<N : Node<*, *>> : NodeRunner<N> {
     }
 
     private fun CoroutineScope.stopNode(node: N) {
-        this.coroutineContext.job.cancel(CancellationException("ShutDownMAS requested"))
+        this.coroutineContext.cancel(CancellationException("Termination requested"))
         //TODO we are brutally killing the agents
         // agents.forEach { removeAgent(it.key.executableAgent.id) }
         // return@launch

--- a/jakta-base-impl/src/commonMain/kotlin/it/unibo/jakta/node/LocalNode.kt
+++ b/jakta-base-impl/src/commonMain/kotlin/it/unibo/jakta/node/LocalNode.kt
@@ -19,8 +19,13 @@ class LocalNode<Body : Any, Skills : Any> : Node<Body, Skills> {
 
     private val _agents: MutableSet<BaseAgent<*, *, *, Body>> = mutableSetOf()
 
+    private val _behaviors: MutableList<NodeBehavior<Body, Skills>> = mutableListOf()
+
     override val agents: Map<AgentID, Body>
         get() = _agents.associate { it.id to it.body }
+
+    override val behaviors: Collection<NodeBehavior<Body, Skills>>
+        get() = _behaviors.toList()
 
     private val _systemEvents: EventBus<SystemEvent> = UnlimitedChannelBus()
 
@@ -38,6 +43,10 @@ class LocalNode<Body : Any, Skills : Any> : Node<Body, Skills> {
             _agents.remove(it)
             _systemEvents.send(AgentRemovalEvent(id))
         }
+    }
+
+    override fun addBehavior(behavior: NodeBehavior<Body, Skills>) {
+        _behaviors.add(behavior)
     }
 
     override fun terminateNode() {

--- a/jakta-base-impl/src/commonTest/kotlin/it/unibo/jakta/ExecutionTest.kt
+++ b/jakta-base-impl/src/commonTest/kotlin/it/unibo/jakta/ExecutionTest.kt
@@ -58,7 +58,7 @@ class ExecutionTest {
             },
         )
 
-        val runner = CoroutineNodeRunner<LocalNode<*, *>>()
+        val runner = CoroutineNodeRunner<Any, MyPrint, LocalNode<Any, MyPrint>>()
 
         runTest {
             agentSpecGenerator("Agent1", node).forEach { node.addAgent(it) }


### PR DESCRIPTION
This pull request closes the exploratory work on nodebehaviors, that can add custom tasks that run within a node and can e.g. implement interaction with sensors that are exposed at the node level. 

While working on this some bugs in the coroutine parent-child relationships were found, these are now fixed and this led to change the API of the AgentLifeCycle to better encapsulate the behavior, including changing the TryStep which now requires simply a dispatcher on which to dispatch the coroutines. (This will be wrapped by the IntentionDispatcher) 